### PR TITLE
Make the callback optional

### DIFF
--- a/lib/jankyqueue.js
+++ b/lib/jankyqueue.js
@@ -34,6 +34,8 @@ var Queue = function(max) {
     };
 
     run = function(fn, args, callback) {
+        if (!callback) callback = function noop() {};
+
         var wrapped = function() {
             var results = arguments,
                 next;

--- a/package.json
+++ b/package.json
@@ -37,10 +37,5 @@
         "url": "git://github.com/e14n/jankyqueue.git"
     },
 
-    "licenses": [
-        {
-            "type": "Apache 2.0",
-            "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-        }
-    ]
+    "license": "Apache-2.0"
 }

--- a/test/module-test.js
+++ b/test/module-test.js
@@ -120,6 +120,34 @@ suite.addBatch({
                     assert.ifError(err);
                 }
             }
+        },
+        "and we create a third instance": {
+            topic: function(Queue) {
+                return new Queue(64);
+            },
+            "it works": function(q) {
+                assert.ok(q);
+            },
+	        "and we enqueue some operations and don't specify a callback": {
+		        topic: function(q) {
+                    var i = 0,
+                        counter = 10,
+                        decr = function(j, cb) {
+                            // do something with j
+	                        counter--;
+	                        cb(null);
+                        };
+
+                    for (i = 0; i < 100; i++) {
+                        q.enqueue(decr, [i]);
+                    }
+
+			        setTimeout(this.callback, 1000);
+		        },
+                "it works": function(err) {
+                    assert.ifError(err);
+                }
+	        }
         }
     }
 });


### PR DESCRIPTION
Also squash npm `package.json` license warnings as a bonus.